### PR TITLE
Allow to pass optional aliasId in arguments for "atomic ssl:cert:activate ..." command

### DIFF
--- a/src/Command/SSL/CertActivateCommand.php
+++ b/src/Command/SSL/CertActivateCommand.php
@@ -15,7 +15,8 @@ class CertActivateCommand extends AbstractSSLCmd
         parent::configure();
         $this->setDescription('Marks a certificate as active for a specific app')
             ->addArgument('certID', InputArgument::REQUIRED, 'Certificate ID')
-            ->addArgument('appId', InputArgument::REQUIRED, 'App ID');
+            ->addArgument('appId', InputArgument::REQUIRED, 'App ID')
+            ->addArgument('aliasId', InputArgument::OPTIONAL, 'Alias ID');
         $this->addOauthOptions();
     }
 
@@ -24,7 +25,8 @@ class CertActivateCommand extends AbstractSSLCmd
         $r = $this->api->activateCertForApp(
             $this->token->token,
             $input->getArgument('certID'),
-            $input->getArgument('appId')
+            $input->getArgument('appId'),
+            $input->getArgument('aliasId')
         );
         if ($r->getStatusCode() === 200) {
             $output->writeln('Success');


### PR DESCRIPTION
When I run command `atomic ssl:cert:activate <certID> <appId>` I got following error:

```
In RequestException.php line 113:

  Server error: `PATCH https://mgmt.pagely.com/api/ssl/activate` resulted in a `512 ` response:
  "Whoops, something broke"
```

Providing third argument did a trick for me and I received a response:
```
Success
```