### PR TITLE
Make apps:create more like Atomic UI functionality

### DIFF
--- a/src/API/Apps/AppsClient.php
+++ b/src/API/Apps/AppsClient.php
@@ -113,13 +113,14 @@ class AppsClient extends BaseApiClient
             ->delete("apps/{$appId}/ips/{$ip}");
     }
 
-    public function createApp($accessToken, $accountId, $name, $primaryDomain, $multisite = false, $multisiteType = null)
+    public function createApp($accessToken, $accountId, $label, $primaryDomain, $multisite = false, $multisiteType = null, $useLabelInSitesDir = false)
     {
         $data = [
-            'name' => $name,
+            'label' => $label,
             'accountId' => (int) $accountId,
             'primaryDomain' => $primaryDomain,
             'multisite' => (bool) $multisite,
+            'name' => $useLabelInSitesDir ? $label : $primaryDomain
         ];
         if ($multisiteType) {
             $data['multisiteType'] = $multisiteType;

--- a/src/Command/Apps/CreateAppCommand.php
+++ b/src/Command/Apps/CreateAppCommand.php
@@ -33,9 +33,11 @@ class CreateAppCommand extends Command
         $this
             ->setDescription('Create new app')
             ->addArgument('accountId', InputArgument::REQUIRED, 'Account ID')
-            ->addArgument('name', InputArgument::REQUIRED, 'App Name/Domain')
+            ->addArgument('label', InputArgument::REQUIRED, 'App Label (name for the appr to appear as in Atomic)')
             ->addArgument('primaryDomain', InputArgument::REQUIRED, 'Primary Domain')
             ->addOption('multisite', 'm', InputOption::VALUE_REQUIRED, 'Enable multisite type (subdomain or subfolder)')
+            ->addOption('use-label-in-sites-dir', null, InputOption::VALUE_NONE, 'Uses the label you have set as the directory name in the ~/sites/ directory when you login to the server.
+            Without this option, the directory will be named the same as the primaryDomain which is the default behavior when creating a site via Atomic.')
         ;
         $this->addOauthOptions();
     }
@@ -49,10 +51,11 @@ class CreateAppCommand extends Command
         $r = $this->api->createApp(
             $token,
             $input->getArgument('accountId'),
-            $input->getArgument('name'),
+            $input->getArgument('label'),
             $input->getArgument('primaryDomain'),
             !!$multi,
-            $multi ?: null
+            $multi ?: null,
+            $input->getOption('use-label-in-sites-dir')
         );
 
         $output->writeln(json_encode(json_decode($r->getBody()->getContents(), true), JSON_PRETTY_PRINT));


### PR DESCRIPTION
Switches the first parameter of `apps:create` to actually be the label, not the name, and adds an additional flag to use the label as the name of the app to match Atomic's behaviour.

Closes #34